### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Graydon Hoare <graydon@pobox.com>"]
 description = "An experiment in panic handling with setjmp/longjmp and arenas"
 license = "MIT OR Apache-2.0"
-repository = "http://github.com/graydon/panic-room"
+repository = "https://github.com/graydon/panic-room"
 keywords = ["panic", "setjmp", "longjmp", "arena"]
 
 [profile.release]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97